### PR TITLE
Adding trailing comma to allow global strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var events = require('events'),
     common = require('winston/lib/winston/common'),
     Transport = require('winston').Transport,
     Stream = require('stream').Stream,
-    os = require('os')
+    os = require('os'),
     winston = require('winston');
 
 //


### PR DESCRIPTION
Otherwise node run with --use_strict crashes like this:

```
ReferenceError: winston is not defined
     at Object.<anonymous> (/home/dmitry/www/api/node_modules/winston-daily-rotate-file/index.js:17:13)
```